### PR TITLE
Use node-type callbacks

### DIFF
--- a/lib/roost.js
+++ b/lib/roost.js
@@ -17,9 +17,9 @@ var makeRequest = function(key, secret, params, callback) {
 
     request(options, function (error, data, response) {
         if (error) {
-            callback('ERROR' + error);
+            callback(error);
         } else {
-            callback(response);
+            callback(null, response);
         }
     });
 };


### PR DESCRIPTION
This library is by-far the only official library that I've used that doesn't follow the node callback structure. (Some description [here](https://docs.nodejitsu.com/articles/getting-started/control-flow/what-are-callbacks)).